### PR TITLE
Update Colyseus, remove mongodb

### DIFF
--- a/CeasarRoom.ts
+++ b/CeasarRoom.ts
@@ -204,7 +204,7 @@ export class CeasarRoom extends Room {
   }
 
   onJoin(client: Client, options: any) {
-    console.log("Joining: ", client.sessionId, options.username);
+    debug(`Joining: ${client.sessionId} ${options.username}`);
     this.state.createPlayer(client.sessionId, options.username);
     const joinResponseData = new UpdateMessage();
     joinResponseData.updateType = "Text"

--- a/CeasarRoom.ts
+++ b/CeasarRoom.ts
@@ -263,7 +263,7 @@ export class CeasarRoom extends Room {
   }
 
   onLeave(client: Client, consented: boolean) {
-    this.broadcast(`${client.sessionId} left.`);
+    this.broadcast("Text", `${client.sessionId} left.`);
     this.reportState();
     debug("wait for reconnection!");
     this.allowReconnection(client, 2)

--- a/CeasarRoom.ts
+++ b/CeasarRoom.ts
@@ -1,7 +1,21 @@
 import { Room, Client } from "colyseus";
 import { Schema, type, MapSchema, ArraySchema } from "@colyseus/schema";
-import { verifyToken, User, IUser } from "@colyseus/social";
+// import { verifyToken, User, IUser } from "@colyseus/social";
 import { debug } from "./utils";
+
+export type NetworkMessageType =
+  "Movement" | "Interaction" | "LocationPin" | "CelestialInteraction" |  "Annotation" | "DeleteAnnotation" | "Heartbeat";
+
+// enum NetworkMessageType
+// {
+//     Movement = "Movement",
+//     Interaction = "Interaction",
+//     LocationPin = "LocationPin",
+//     CelestialInteraction = "CelestialInteraction",
+//     Annotation = "Annotation",
+//     DeleteAnnotation = "Deleteannotation",
+//     Heartbeat = "Heartbeat"
+// }
 
 class NetworkVector3 extends Schema {
   @type("number")
@@ -123,14 +137,15 @@ export class State extends Schema {
   @type({ map: NetworkPlayer })
   players = new MapSchema<NetworkPlayer>();
 
-  createPlayer (id: string, username: string) {
+  createPlayer(id: string, username: string) {
+    debug(`creating player ${id}: ${username}`)
     this.players[id] = new NetworkPlayer();
     this.players[id].username = username;
     this.players[id].id = id;
   }
 
   removePlayer (id: string) {
-      delete this.players[ id ];
+      delete this.players[id];
   }
 
   movePlayer(id: string, movementTransform: any) {
@@ -177,14 +192,21 @@ export class UpdateMessage extends Schema {
   metadata = "";
 }
 export class CeasarRoom extends Room {
-  onCreate(options: any) {
+  onCreate() {
     debug(`CeasarRoom created ${this.roomName}`);
     this.setState(new State());
+
+    this.onMessage("*", (client: any, messageType: any, data: any) => {
+      debug(`received message "${messageType}" from ${client.sessionId}`);
+      if (!this.state.players[client.sessionId]) debug("player not yet joined");
+      else (this.handleMessageReceived(messageType, client, data));
+    });
   }
 
-  async onAuth(client: Client, options: any) {
-    debug(`onAuth(), options! ${options}`);
-    return await User.findById(verifyToken(options.token)._id);
+  onAuth(client: Client, options: any) {
+    return client;
+    // debug(`onAuth(), options! ${options}`);
+    // return await User.findById(verifyToken(options.token)._id);
   }
 
   reportState() {
@@ -192,9 +214,10 @@ export class CeasarRoom extends Room {
     debug(this.state.toJSON());
   }
 
-  onJoin(client: Client, options: any, user: IUser) {
+  onJoin(client: Client, options: any) {
+    console.log("Joining: ", client.sessionId, options.username);
     this.state.createPlayer(client.sessionId, options.username);
-    this.broadcast(`${client.sessionId} joined.`);
+    // this.broadcast(`${client.sessionId} joined.`);
     this.reportState();
   }
 
@@ -209,48 +232,44 @@ export class CeasarRoom extends Room {
     this.broadcast(responseData, { afterNextPatch: true, except: client });
   }
 
-  onMessage(client: Client, data: any) {
-    switch (data.message) {
-      case "movement":
-        debug(`CeasarRoom received movement from ${client.sessionId}: ${data}`);
-        this.state.movePlayer(client.sessionId, data.transform);
-        this.sendUpdateMessage("movement", client);
+  handleMessageReceived(messageType: string, client: any, data: any) {
+    debug(`CeasarRoom received ${messageType} from ${client.sessionId}`);
+    switch (messageType) {
+      case "Movement":
+        this.state.movePlayer(client.sessionId, data);
+        this.sendUpdateMessage("Movement", client);
         break;
-      case "interaction":
-        debug(`CeasarRoom received interaction from ${client.sessionId}: ${data}`);
-        this.state.syncInteraction(client.sessionId, data.transform);
-        this.sendUpdateMessage("interaction", client);
+      case "Interaction":
+        this.state.syncInteraction(client.sessionId, data);
+        this.sendUpdateMessage("Interaction", client);
         break;
-      case "locationpin":
-        debug(`CeasarRoom received locationpin from ${client.sessionId}: ${data}`);
-        this.state.syncLocationPin(client.sessionId, data.perspectivePin);
-        this.sendUpdateMessage("locationpin", client);
+      case "LocationPin":
+        this.state.syncLocationPin(client.sessionId, data);
+        this.sendUpdateMessage("LocationPin", client);
         break;
-      case "celestialinteraction":
-        debug(`CeasarRoom received celestialInteraction from ${client.sessionId}: ${data}`);
-        this.state.syncCelestialObjectInteraction(client.sessionId, data.celestialObject);
-        this.sendUpdateMessage("celestialinteraction", client);
+      case "CelestialInteraction":
+        this.state.syncCelestialObjectInteraction(client.sessionId, data);
+        this.sendUpdateMessage("CelestialInteraction", client);
         break;
-      case "annotation":
-        debug(`CeasarRoom received annotation from ${client.sessionId}: ${data}`);
-        this.state.syncAnnotation(client.sessionId, data.transform);
-        this.sendUpdateMessage("annotation", client);
+      case "Annotation":
+        this.state.syncAnnotation(client.sessionId, data);
+        this.sendUpdateMessage("Annotation", client);
         break;
-      case "deleteannotation":
-        debug(`CeasarRoom received delete annotation from ${client.sessionId}: ${data}`);
-        this.state.syncDeleteAnnotation(client.sessionId, data.annotationName);
-        this.sendUpdateMessage("deleteannotation", client, data.annotationName);
+      case "DeleteAnnotation":
+        this.state.syncDeleteAnnotation(client.sessionId, data);
+        this.sendUpdateMessage("DeleteAnnotation", client, data);
         break;
-      case "heartbeat":
+      case "Heartbeat":
         // do nothing
         break;
       default:
-        debug(`CeasarRoom received unknown message from ${client.sessionId}: ${data}`);
-        this.broadcast({ message: `(${client.sessionId}) ${data.message}` });
+        debug(`CeasarRoom received unknown message of type: ${messageType}: ${JSON.stringify(data)}`);
+        // this.broadcast(messageType, { message: `(${client.sessionId}) ${data.message}` });
         break;
     }
     this.reportState();
   }
+
   onLeave(client: Client, consented: boolean) {
     this.broadcast(`${client.sessionId} left.`);
     this.reportState();

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `ceasar-server`
 
-A CEASER Game server based on `create-colyseus-app`.
+A multiplayer game server for the [CEASAR](https://github.com/concord-consortium/CEASAR) project, based on [Colyseus](https://colyseus.io).
 
 ## :crossed_swords: Usage
 * If this is the first time running the app, run: `npm install`
@@ -11,12 +11,6 @@ A CEASER Game server based on `create-colyseus-app`.
 ### Local requirements:
 You will need to add a local `.env` file to this project directory.
 *Important: `.env` should always be included in `.gitignore`*
-
-The `.env` file should contain one environmental variable for the mongo server:
-
-```
-    MONGO_URI=mongodb://[user]:[password]@[host]
-```
 
 You will need to obtain that URI from another developer or from
 Config Var of the same name in the Heroku [ceaser-server-staging app](https://dashboard.heroku.com/apps/ceaser-server-staging/settings).
@@ -54,13 +48,9 @@ folder, then `start` is run, which executes `node dist/index.ts`.
 
 ### Preview Branches
 Pushing changes to *any* branch should cause a Heroku preview app to be built.
-You will need to configure the apps settings, to add a `MONGO_URI` config var.
-For now you can just copy the `MONGO_URI` config var from the
-[staging-app settings](https://dashboard.heroku.com/apps/ceasar-server-staging/settings).
 
 ### Staging Branch
 Pushing changes to *`master`* will cause the Heroku staging sever to update.
-The staging server is already provisioned with configured MLAb Mongo Heroku addon.
 
 The heroku app websocket server should be available at:
 wss://ceasar-server-staging.concord.org/ or
@@ -70,13 +60,11 @@ This is not configured yet, but will be configured similar to how the staging br
 
 ## Project Structure
 
-- `index.ts`: main entry point, register an empty room handler and attach [`@colyseus/monitor`](https://github.com/colyseus/colyseus-monitor)
-- `MyRoom.ts`: an empty room handler for you to implement your logic
-- `loadtest/example.ts`: scriptable client for the loadtest tool (see `npm run loadtest`)
+- `index.ts`: main entry point, register room handlers and attach [`@colyseus/monitor`](https://github.com/colyseus/colyseus-monitor)
+- `CeasarRoom.ts`: The main room handler, contains all schema definitions and room state
 - `package.json`:
     - `scripts`:
         - `npm live`: runs `ts-node index.ts`
-        - `npm run loadtest`: runs the [`@colyseus/loadtest`](https://github.com/colyseus/colyseus-loadtest/) tool for testing the connection, using the `loadtest/example.ts` script.
     - `dependencies`:
         - `colyseus`
         - `@colyseus/monitor`
@@ -85,7 +73,6 @@ This is not configured yet, but will be configured similar to how the staging br
     - `devDependencies`
         - `ts-node`
         - `typescript`
-        - `@colyseus/loadtest`
         - `rimraf`
 - `tsconfig.json`: TypeScript configuration file
 

--- a/index.ts
+++ b/index.ts
@@ -12,13 +12,12 @@ import { CeasarRoom } from "./CeasarRoom";
 const port = Number(process.env.PORT || 2567);
 const app = express();
 app.use(cors());
-app.use(express.json());
+// app.use(express.json());
 
-const server = http.createServer(app);
 const gameServer = new Server({
-  server,
-  express: app,
-  pingTimeout: 0
+  server: http.createServer(app),
+  // express: app,
+  pingInterval: 0
 });
 
 const roomNames =
@@ -28,14 +27,13 @@ const roomNames =
   'eta', 'theta', 'iota'
 ];
 
-roomNames.forEach(name => gameServer.define(name, CeasarRoom));
-
 // register your room handlers
-gameServer.define('ceasar', CeasarRoom);
+roomNames.forEach(name => gameServer.define(name, CeasarRoom));
+// gameServer.define('ceasar', CeasarRoom);
 
 // app.use("/", socialRoutes);
 // register colyseus monitor AFTER registering your room handlers
-// app.use("/colyseus", monitor(gameServer) );
+app.use("/colyseus", monitor() );
 
 gameServer.listen(port);
 // v1 used ws://calm-meadow-14344.herokuapp.com:2567

--- a/index.ts
+++ b/index.ts
@@ -7,16 +7,12 @@ import { Server } from "colyseus";
 import { monitor } from "@colyseus/monitor";
 import { CeasarRoom } from "./CeasarRoom";
 
-// import socialRoutes from "@colyseus/social/express";
-
 const port = Number(process.env.PORT || 2567);
 const app = express();
 app.use(cors());
-// app.use(express.json());
 
 const gameServer = new Server({
   server: http.createServer(app),
-  // express: app,
   pingInterval: 0
 });
 
@@ -29,12 +25,9 @@ const roomNames =
 
 // register your room handlers
 roomNames.forEach(name => gameServer.define(name, CeasarRoom));
-// gameServer.define('ceasar', CeasarRoom);
 
-// app.use("/", socialRoutes);
 // register colyseus monitor AFTER registering your room handlers
 app.use("/colyseus", monitor() );
 
 gameServer.listen(port);
-// v1 used ws://calm-meadow-14344.herokuapp.com:2567
 console.log(`Listening on port:${ port }`)

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import { Server } from "colyseus";
 import { monitor } from "@colyseus/monitor";
 import { CeasarRoom } from "./CeasarRoom";
 
-import socialRoutes from "@colyseus/social/express";
+// import socialRoutes from "@colyseus/social/express";
 
 const port = Number(process.env.PORT || 2567);
 const app = express();
@@ -33,9 +33,9 @@ roomNames.forEach(name => gameServer.define(name, CeasarRoom));
 // register your room handlers
 gameServer.define('ceasar', CeasarRoom);
 
-app.use("/", socialRoutes);
+// app.use("/", socialRoutes);
 // register colyseus monitor AFTER registering your room handlers
-app.use("/colyseus", monitor(gameServer));
+// app.use("/colyseus", monitor(gameServer) );
 
 gameServer.listen(port);
 // v1 used ws://calm-meadow-14344.herokuapp.com:2567

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,48 +5,18 @@
   "requires": true,
   "dependencies": {
     "@colyseus/monitor": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@colyseus/monitor/-/monitor-0.11.9.tgz",
-      "integrity": "sha512-ydnScwz0tM2BaUdscQ/cRWF5udoUchS6kgMTnDFVciDFyveAOY7WsoFRUKt4cfGuNiYY5REQMYPae1Yc2HcgJA==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/monitor/-/monitor-0.12.2.tgz",
+      "integrity": "sha512-48oZxz4uVZszhyWf2NqCNXw3mlIGhRgUYOwBu6/e6XGD82qS0VQRdfOg5neplJLPvZSSNyKnEz3G5mVzc7iYsQ==",
       "requires": {
-        "express": "^4.16.3"
+        "express": "^4.16.3",
+        "node-os-utils": "^1.2.0"
       }
     },
     "@colyseus/schema": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/@colyseus/schema/-/schema-0.5.14.tgz",
-      "integrity": "sha512-2i1t2+BwuGIoRxptDdu+c3QsLazTvRVuF6kFr7tm+Q9DdZEJV9x2LxfJotLWLXfxKjsG8swuWuxOV1z0Bn1gSw=="
-    },
-    "@colyseus/social": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@colyseus/social/-/social-0.11.6.tgz",
-      "integrity": "sha512-BNZaf2elZzcR92yw14rLQ9LKfyfwQQ7peBvBaK2jxyNbEIKWe4Y4lAi1igNY/2qpmsaosxmvnji8QOKUm5aI2g==",
-      "requires": {
-        "@types/mongoose": "^5.3.27",
-        "debug": "^4.1.1",
-        "httpie": "^1.1.2",
-        "jsonwebtoken": "^8.5.1",
-        "mongoose": "^5.5.6",
-        "nanoid": "^2.0.2",
-        "node-pushnotifications": "^1.1.8",
-        "oauth": "^0.9.15",
-        "strong-events": "^1.0.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/@colyseus/schema/-/schema-0.5.41.tgz",
+      "integrity": "sha512-yJXSK6S1bAyWTKuxfNQ2u3KAVHjornnDg8hvbX7T+ZfX8BiYGBTbiv5JIUG9bYXbMRqQnQYa5QlPHjU30R7rJQ=="
     },
     "@gamestdio/clock": {
       "version": "1.1.9",
@@ -54,38 +24,11 @@
       "integrity": "sha1-d+wMAROR+7/ctPMhEkKVNv2GgMs="
     },
     "@gamestdio/timer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@gamestdio/timer/-/timer-1.3.1.tgz",
-      "integrity": "sha512-WEucGxBEYBaja/YCCGCAeHkPpkZYkybJ4BfLH0HMJ2+n8RKmpjeYbx0j2TevADkk5mJ7gO48hbE+hcL/y5V45g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@gamestdio/timer/-/timer-1.3.2.tgz",
+      "integrity": "sha512-l6Mrlibx8ScmEAbTKxtZ3QJD8z3htzl1wxSRopFyDwudq73nb+pYvRYERrj5+rZLjA6cX0Nt+OKTRXBi/BSejw==",
       "requires": {
         "@gamestdio/clock": "^1.1.9"
-      }
-    },
-    "@parse/node-apn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-3.1.0.tgz",
-      "integrity": "sha512-uEf6hL2WOFle5e9JUpbVwYUWYupqeiVS6StibkiYY4Bw3GmjYoZvHZu7DbGxQedJ85EjxuCYXFfopudiUElRpQ==",
-      "requires": {
-        "coveralls": "^3.0.6",
-        "debug": "^3.1.0",
-        "jsonwebtoken": "^8.1.0",
-        "node-forge": "^0.7.1",
-        "verror": "^1.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "@types/body-parser": {
@@ -94,14 +37,6 @@
       "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
       "requires": {
         "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/bson": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.1.tgz",
-      "integrity": "sha512-K6VAEdLVJFBxKp8m5cRTbUfeZpuSvOuLKJLrgw9ANIXo00RiyGzgH4BKWWR4F520gV4tWmxG7q9sKQRVDuzrBw==",
-      "requires": {
         "@types/node": "*"
       }
     },
@@ -162,24 +97,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
-    "@types/mongodb": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.3.13.tgz",
-      "integrity": "sha512-ZRNmQefIMIGvPQuT8s0z7Kx8A343dtcepJ4m9l8JwRgyJ6cy15ufDJK5uydrZNKmuU/GKWW2EtZ+CzMQt1GhBQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/mongoose": {
-      "version": "5.5.34",
-      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.5.34.tgz",
-      "integrity": "sha512-XSXKMIZimxx8q17RGQArawrTVI8021PPbP21WEq71YTUMpVuaJaN9yFQll5KtEif5Jw1cphxEFkNwrDmuG+NFA==",
-      "requires": {
-        "@types/mongodb": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "12.12.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
@@ -191,9 +108,9 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/redis": {
-      "version": "2.8.14",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.14.tgz",
-      "integrity": "sha512-255dzsOLJdXFHBio9/aMHGozNkoiBUgc+g2nlNjbTSp5qcAlmpm4Z6Xs3pKOBLNIKdZbA2BkUxWvYSIwKra0Yw==",
+      "version": "2.8.27",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.27.tgz",
+      "integrity": "sha512-RRHarqPp3mgqHz+qzLVuQCJAIVaB3JBaczoj24QVVYu08wiCmB8vbOeNeK9lIH+pyT7+R/bbEPghAZZuhbZm0g==",
       "requires": {
         "@types/node": "*"
       }
@@ -224,108 +141,31 @@
         "negotiator": "0.6.2"
       }
     },
-    "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
-    },
-    "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
     "arg": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
       "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg=="
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
     },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "asn1.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
-      "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-    },
-    "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "optional": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -356,7 +196,8 @@
     "bson": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
+      "optional": true
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -373,22 +214,12 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "colyseus": {
-      "version": "0.11.25",
-      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.11.25.tgz",
-      "integrity": "sha512-IaUL04tPc/SRGHzsU4dL7TkdHOzCA5ZkTimDO1azSWlxkjUtX+lVOXXNM1bMrgwix54OsD9PGQoQRi0Bu5l2rQ==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.13.7.tgz",
+      "integrity": "sha512-MalA6bHWFyz5c3o7wmSuOnVqZUBAdDaGv9OWc5kI0/jteyMn5BkqjxXV7IHhRy+B3DQGJOxLSnvoOFIy9eIf/A==",
       "requires": {
-        "@colyseus/schema": "^0.5.1",
+        "@colyseus/schema": "^0.5.19",
         "@gamestdio/timer": "^1.3.0",
         "@types/redis": "^2.8.12",
         "@types/ws": "^6.0.1",
@@ -405,11 +236,11 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -417,14 +248,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
-      }
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
       }
     },
     "concat-map": {
@@ -455,11 +278,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -467,18 +285,6 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
-      }
-    },
-    "coveralls": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
-      "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
-        "request": "^2.88.0"
       }
     },
     "cross-spawn": {
@@ -491,14 +297,6 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -517,11 +315,6 @@
         "execa": "^1.0.0",
         "ip-regex": "^2.1.0"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -549,15 +342,6 @@
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
       "optional": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -584,28 +368,10 @@
         "once": "^1.4.0"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "etag": {
       "version": "1.8.1",
@@ -679,16 +445,6 @@
       "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
       "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -702,11 +458,6 @@
         "fast-deep-equal": "^2.0.1"
       }
     },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -719,21 +470,6 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
-      }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -764,14 +500,6 @@
         "pump": "^3.0.0"
       }
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -785,20 +513,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -809,53 +523,6 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
-    "http_ece": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.1.0.tgz",
-      "integrity": "sha512-bptAfCDdPJxOs5zYSe7Y3lpr772s1G346R4Td5LgRUeCwIGpCGDUTJxRrhTNcAXbx37spge0kWEIH7QAYWNTlA==",
-      "requires": {
-        "urlsafe-base64": "~1.0.0"
-      }
-    },
-    "httpie": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/httpie/-/httpie-1.1.2.tgz",
-      "integrity": "sha512-VQ82oXG95oY1fQw/XecHuvcFBA+lZQ9Vwj1RfLcO8a7HpDd4cc2ukwpJt+TUlFaLUAzZErylxWu6wclJ1rUhUQ=="
-    },
-    "https-proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
-      "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "iconv-lite": {
@@ -904,49 +571,10 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -972,17 +600,6 @@
         }
       }
     },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -1005,17 +622,8 @@
     "kareem": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
-      "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
-    },
-    "lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A="
-    },
-    "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==",
+      "optional": true
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -1056,11 +664,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "make-error": {
       "version": "1.3.5",
@@ -1106,11 +709,6 @@
         "mime-db": "1.42.0"
       }
     },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1119,15 +717,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
     "mongodb": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.5.tgz",
       "integrity": "sha512-6NAv5gTFdwRyVfCz+O+KDszvjpyxmZw+VlmqmqKR2GmpkeKrKFRv/ZslgTtZba2dc9JYixIf99T5Gih7TIWv7Q==",
+      "optional": true,
       "requires": {
         "bson": "^1.1.1",
         "require_optional": "^1.0.1",
@@ -1139,6 +733,7 @@
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.1.tgz",
       "integrity": "sha512-8Cffl52cMK2iBlpLipoRKW/RdrhkxvVzXsy+xVsfbKHQBCWkFiS0T0jU4smYzomTMP4gW0sReJoRA7Gu/7VVgQ==",
+      "optional": true,
       "requires": {
         "bson": "~1.1.1",
         "kareem": "2.3.1",
@@ -1156,24 +751,28 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "optional": true
         }
       }
     },
     "mongoose-legacy-pluralize": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
+      "optional": true
     },
     "mpath": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
-      "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
+      "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw==",
+      "optional": true
     },
     "mquery": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
       "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
+      "optional": true,
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -1186,6 +785,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1212,133 +812,10 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
-    "node-adm": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/node-adm/-/node-adm-0.9.1.tgz",
-      "integrity": "sha1-+ManL/rbGn39ZjcQLJUKmpSW6EI="
-    },
-    "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
-    },
-    "node-gcm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/node-gcm/-/node-gcm-1.0.2.tgz",
-      "integrity": "sha512-NEVb5jB06I/e9ZfJGWhHsRhJQLk1zO5iZjbQJ7su8j9vhHrpxc7KJHyBxWbv28+4uWFZ0AfTVHoMIyRpEVISUQ==",
-      "requires": {
-        "debug": "^3.1.0",
-        "lodash": "^4.17.10",
-        "request": "2.87.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        },
-        "request": {
-          "version": "2.87.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        }
-      }
-    },
-    "node-pushnotifications": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-pushnotifications/-/node-pushnotifications-1.2.0.tgz",
-      "integrity": "sha512-QXIrymHS1dH75MF6i7zk8tH6LK8CaJwWhHg57selBOJQ+3NE8vg/9VUvrqlEIgCdMmi22pIUPkvcSamUdtvlQg==",
-      "requires": {
-        "@parse/node-apn": "3.1.0",
-        "node-adm": "0.9.1",
-        "node-gcm": "1.0.2",
-        "ramda": "0.26.1",
-        "web-push": "3.4.1",
-        "wns": "0.5.4"
-      }
+    "node-os-utils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-os-utils/-/node-os-utils-1.3.2.tgz",
+      "integrity": "sha512-wUo/q6u77y9+DBaXkn57IDyJlQuN7xP6VU9h6yeIGhKocc9rDQPyc3WmLgX+x5jf4WmbLcEaA3raM05+v5jW3g=="
     },
     "nonenumerable": {
       "version": "1.1.1",
@@ -1346,9 +823,9 @@
       "integrity": "sha512-ptUD9w9D8WqW6fuJJkZNCImkf+0vdbgUTbRK3i7jsy3olqtH96hYE6Q/S3Tx9NWbcB/ocAjYshXCAUP0lZ9B4Q=="
     },
     "notepack.io": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-      "integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
+      "integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -1357,16 +834,6 @@
       "requires": {
         "path-key": "^2.0.0"
       }
-    },
-    "oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1414,11 +881,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -1427,11 +889,6 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
       }
-    },
-    "psl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
-      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA=="
     },
     "pump": {
       "version": "3.0.0",
@@ -1442,20 +899,10 @@
         "once": "^1.3.1"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-    },
-    "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -1485,9 +932,9 @@
       }
     },
     "redis-commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
-      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==",
       "optional": true
     },
     "redis-parser": {
@@ -1499,46 +946,14 @@
     "regexp-clone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
-    },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        }
-      }
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
+      "optional": true
     },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "optional": true,
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -1547,7 +962,8 @@
     "resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "optional": true
     },
     "rimraf": {
       "version": "3.0.0",
@@ -1640,17 +1056,19 @@
     "sift": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
-      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==",
+      "optional": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
+      "optional": true
     },
     "source-map": {
       "version": "0.6.1",
@@ -1675,27 +1093,6 @@
         "memory-pager": "^1.0.2"
       }
     },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -1706,31 +1103,10 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
-    "strong-events": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/strong-events/-/strong-events-1.0.7.tgz",
-      "integrity": "sha512-zKYPfTtLaZiwDoDiGkNQdurbGhzVS7oE23AmHOnA6rUp4E7FeF7Z6xbHQEqSRqNyaTN+X3rcppfobypf0k3Ltg=="
-    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
     },
     "ts-node": {
       "version": "8.5.4",
@@ -1743,19 +1119,6 @@
         "source-map-support": "^0.5.6",
         "yn": "^3.0.0"
       }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-is": {
       "version": "1.6.18",
@@ -1776,56 +1139,15 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "urlsafe-base64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
-      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "web-push": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.4.1.tgz",
-      "integrity": "sha512-wtx18llPtWWW+x8hv+Gxvz+2VjO+vZuyihInsjySNpNGNVswH1Bb2KkbbCtE96yi52VUmbFMdidxM8kJAPaSWQ==",
-      "requires": {
-        "asn1.js": "^5.0.0",
-        "http_ece": "1.1.0",
-        "https-proxy-agent": "^3.0.0",
-        "jws": "^3.1.3",
-        "minimist": "^1.2.0",
-        "urlsafe-base64": "^1.0.0"
-      }
     },
     "which": {
       "version": "1.3.1",
@@ -1835,20 +1157,15 @@
         "isexe": "^2.0.0"
       }
     },
-    "wns": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/wns/-/wns-0.5.4.tgz",
-      "integrity": "sha512-WYiJ7khIwUGBD5KAm+YYmwJDDRzFRs4YGAjtbFSoRIdbn9Jcix3p9khJmpvBTXGommaKkvduAn+pc9l4d9yzVQ=="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
-      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "start": "node dist/index.js",
     "live": "ts-node index.ts",
-    "loadtest": "colyseus-loadtest loadtest/example.ts --room my_room --numClients 2",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",

--- a/package.json
+++ b/package.json
@@ -22,18 +22,17 @@
   },
   "homepage": "https://github.com/colyseus/ceasar-colyseus#readme",
   "dependencies": {
+    "@colyseus/monitor": "^0.12.2",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.1",
     "@types/express-jwt": "0.0.42",
-    "rimraf": "^3.0.0",
-    "ts-node": "^8.4.1",
-    "typescript": "^3.6.3",
-    "@colyseus/monitor": "^0.11.9",
-    "@colyseus/social": "^0.11.6",
-    "colyseus": "^0.11.24",
+    "colyseus": "^0.13.7",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.16.4",
     "express-jwt": "^5.3.1",
-    "dotenv": "^8.2.0"
+    "rimraf": "^3.0.0",
+    "ts-node": "^8.4.1",
+    "typescript": "^3.6.3"
   }
 }


### PR DESCRIPTION
Removed the unused Auth pieces from Colyseus Social and hence the dependency on MongoDB. If we need to roll in authentication later on, we can roll our own based on [colyseus-social](https://github.com/colyseus/colyseus-social) 